### PR TITLE
refactor pyboard target to be based on a new generic upstream STM32F405 target

### DIFF
--- a/CMake/toolchain.cmake
+++ b/CMake/toolchain.cmake
@@ -13,24 +13,7 @@
 # limitations under the License.
 #
 
-if(TARGET_STM32F405RG_GCC_TOOLCHAIN_INCLUDED)
+if(TARGET_PYBOARD_GCC_TOOLCHAIN_INCLUDED)
     return()
 endif()
-set(TARGET_STM32F405RG_GCC_TOOLCHAIN_INCLUDED 1)
-
-# provide compatibility definitions for compiling with this target: these are
-# definitions that legacy code assumes will be defined. Before adding something
-# here, think VERY CAREFULLY if you can't change anywhere that relies on the
-# definition that you're about to add to rely on the TARGET_LIKE_XXX
-# definitions that yotta provides based on the target.json file.
-#
-add_definitions("-DTARGET_STM32F405RG -DTARGET_STM32F405RG -DSTM32F405xx -DTARGET_STM32F4")
-
-set(_CPU_COMPILATION_OPTIONS "-mcpu=cortex-m4 -mthumb -mfpu=fpv4-sp-d16 -mfloat-abi=hard")
-set(_CPU_DEFINES "-D__thumb2__ ")
-
-set(CMAKE_C_FLAGS_INIT             "${CMAKE_C_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
-set(CMAKE_ASM_FLAGS_INIT           "${CMAKE_ASM_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
-set(CMAKE_CXX_FLAGS_INIT           "${CMAKE_CXX_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} ${_CPU_DEFINES}")
-set(CMAKE_MODULE_LINKER_FLAGS_INIT "${CMAKE_MODULE_LINKER_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS}")
-set(CMAKE_EXE_LINKER_FLAGS_INIT    "${CMAKE_EXE_LINKER_FLAGS_INIT} ${_CPU_COMPILATION_OPTIONS} -T\"${CMAKE_CURRENT_LIST_DIR}/../ld/STM32F405RG.ld\"")
+set(TARGET_PYBOARD_GCC_TOOLCHAIN_INCLUDED 1)

--- a/target.json
+++ b/target.json
@@ -1,12 +1,12 @@
 {
-  "name": "stm32f405-pyboard-gcc",
-  "version": "0.0.1",
+  "name": "pyboard-gcc",
+  "version": "0.0.2",
   "inherits": {
-    "kubos-arm-none-eabi-gcc": "openkosmosorg/target-kubos-arm-none-eabi-gcc#~0.0.1"
+    "stm32f405-gcc": "openkosmosorg/target-stm32f405-gcc#~0.0.1"
   },
   "description": "KubOS build target for the stm32f405rg based PyBoard.",
   "author": "Ryan Plauche <ryan@kubos.co>",
-  "homepage": "https://github.com/openkosmosorg/target-stm32f405-pyboard-gcc",
+  "homepage": "https://github.com/openkosmosorg/target-pyboard-gcc",
   "licenses": [
     {
       "url": "https://spdx.org/licenses/Apache-2.0",
@@ -31,20 +31,8 @@
     "armv7-m"
   ],
   "config": {
-    "cmsis": {
-      "nvic": {
-        "ram_vector_address": "0x20000000",
-        "flash_vector_address": "0x08000000",
-        "user_irq_offset": 16,
-        "user_irq_number": 82
-      }
-    },
-    "uvisor": {
-      "present": 0
-    },
     "hardware": {
       "externalClock": "8000000",
-      "uartCount": "6",
       "console": {
         "uart": "K_UART6",
         "baudRate": "115200"
@@ -54,42 +42,7 @@
         "LED2": "PA15",
         "LED3": "PA13",
         "LED4": "PB4",
-        "USER_BUTTON": "PB3",
-        "UART1_TX": "PB6",
-        "UART1_RX": "PB7",
-        "UART2_TX": "PA2",
-        "UART2_RX": "PA3",
-        "UART3_TX": "PB10",
-        "UART3_RX": "PB11",
-        "UART4_TX": "PA0",
-        "UART4_RX": "PA1",
-        "UART6_TX": "PC6",
-        "UART6_RX": "PC7",
-        "USBTX": "PA_2",
-        "USBRX": "PA_3",
-        "I2C_SCL": "PB6",
-        "I2C_SDA": "PB7",
-        "SPI_MOSI": "PA7",
-        "SPI_MISO": "PA6",
-        "SPI_SCK": "PA5",
-        "SPI_CS": "PA_4",
-        "PWM_OUT": "PB_3"
-      },
-      "test-pins": {
-        "spi": {
-          "mosi": "SPI_MOSI",
-          "miso": "SPI_MISO",
-          "sclk": "SPI_SCK",
-          "ssel": "SPI_CS"
-        },
-        "i2c": {
-          "sda": "I2C_SDA",
-          "scl": "I2C_SCL"
-        },
-        "serial": {
-          "tx": "PC_12",
-          "rx": "PF_6"
-        }
+        "USER_BUTTON": "PB3"
       }
     }
   },


### PR DESCRIPTION
* renamed target to "pyboard-gcc"
* bumped to v0.0.2

*Note* the Upstream openkosmosorg/target-stm32f405-pyboard-gcc repository needs to be renamed to target-pyboard-gcc once this is merged

openkosmosorg/KubOS#16